### PR TITLE
Issue 3/chapter markers xml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,4 +28,4 @@ virtualenv-clone = "==0.5.7"
 [dev-packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2db46ee90686abe3180862e04afdc258bc03f92b4f5984ae4460069139fc1dea"
+            "sha256": "d0fc7e3edf6eeb90039b96864c9896a8449dff4fb28c2a8fe322035974b3cce5"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.10"
         },
         "sources": [
             {

--- a/splitter.py
+++ b/splitter.py
@@ -165,9 +165,6 @@ def split_file(filename: str, segments: List[Tuple[str, str, str]]) -> List[str]
                 print(f"Created {segname}")
         else:
             print(f"File {segname} already exists")
-            # the following can be handy for debugging ffmpeg issues
-            # for line in output.splitlines():
-            # print(f"Got line: {line}")
     return segs
 
 


### PR DESCRIPTION
Running the splitter on a file now creates a filename.xml file in the same folder. If the xml file is copied with the name filename_fixed.xml and the existing file/split files deleted, it will be recreated with the chapter titles in the filename_fixed.xml file. 